### PR TITLE
EDX-3320 Add Keeper as a new security token type during bootstrap

### DIFF
--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	TokenTypeConsul      = "consul"
+	TokenTypeKeeper      = "keeper"
 	AccessTokenAuthError = "HTTP response with status code 403"
 	//nolint: gosec
 	SecretsAuthError = "Received a '403' response"
@@ -246,10 +247,11 @@ func (p *SecureProvider) GetAccessToken(tokenType string, serviceKey string) (st
 		serviceKey = "app-service"
 		p.lc.Infof("[EdgeXpert] Overwrote ASC serviceKey")
 	}
-
-	p.securityConsulTokensRequested.Inc(1)
-	started := time.Now()
-	defer p.securityConsulTokenDuration.UpdateSince(started)
+	if tokenType == TokenTypeConsul {
+		p.securityConsulTokensRequested.Inc(1)
+		started := time.Now()
+		defer p.securityConsulTokenDuration.UpdateSince(started)
+	}
 
 	switch tokenType {
 	case TokenTypeConsul:
@@ -266,6 +268,9 @@ func (p *SecureProvider) GetAccessToken(tokenType string, serviceKey string) (st
 		}
 
 		return token, nil
+	case TokenTypeKeeper:
+		// return empty token for Keeper as we don't need a token to access to it in security mode
+		return "", nil
 
 	default:
 		return "", fmt.Errorf("invalid access token type '%s'", tokenType)


### PR DESCRIPTION
Add Keeper token type and returns a empty string during bootstrap to be used in security mode.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->