### PR TITLE
EDX-4442 Add Keeper support for ListenForCustomConfigChanges

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -290,7 +290,7 @@ func (cp *Processor) LoadCustomConfigSection(config interfaces.UpdatableConfig, 
 }
 
 // ListenForCustomConfigChanges listens for changes to the specified custom configuration section. When changes occur it
-// applies the changes to the custom configuration section and signals the the changes have occurred.
+// applies the changes to the custom configuration section and signals the changes have occurred.
 func (cp *Processor) ListenForCustomConfigChanges(
 	configToWatch interface{},
 	sectionName string,
@@ -315,6 +315,11 @@ func (cp *Processor) ListenForCustomConfigChanges(
 		configProviderUrl := cp.flags.ConfigProviderUrl()
 		// check if the config provider type is keeper
 		if strings.HasPrefix(configProviderUrl, secret.TokenTypeKeeper) {
+			// there's no startupTimer for cp created by NewProcessorForCustomConfig
+			// add a new startupTimer here
+			if !cp.startupTimer.HasNotElapsed() {
+				cp.startupTimer = startup.NewStartUpTimer("")
+			}
 			for cp.startupTimer.HasNotElapsed() {
 				if msgClient := container.MessagingClientFrom(cp.dic.Get); msgClient != nil {
 					messageBus = msgClient


### PR DESCRIPTION
Add Keeper support for ListenForCustomConfigChanges.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->