### PR TITLE
PS-881: Add Middleware to handle RequestTimeout

### DIFF
--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
- * Copyright 2021-2023 IOTech Ltd
+ * Copyright 2021-2026 IOTech Ltd
  * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -35,7 +35,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 )
 
 // HttpServer contains references to dependencies required by the http server implementation.
@@ -122,9 +121,10 @@ func (b *HttpServer) BootstrapHandler(
 		return false
 	}
 
-	b.router.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
-		Timeout: timeout,
-	}))
+	if timeout > 0 {
+		// Apply timeout middleware only when timeout is set
+		b.router.Use(RequestTimeoutMiddleware(timeout))
+	}
 
 	b.router.Use(RequestLimitMiddleware(bootstrapConfig.Service.MaxRequestSize, lc))
 
@@ -178,6 +178,37 @@ func (b *HttpServer) BootstrapHandler(
 	}()
 
 	return true
+}
+
+// RequestTimeoutMiddleware enforces a request timeout using http.TimeoutHandler.
+// The client receives a 503 immediately when the timeout is exceeded.
+//
+// Unlike echo's ContextTimeout which only sets a context deadline and requires the handler
+// to handle ctx.Done(), http.TimeoutHandler responds to the client immediately on timeout.
+func RequestTimeoutMiddleware(timeout time.Duration) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			h := http.TimeoutHandler(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// - Replace the request so that c.Request().Context() carries the timeout context from TimeoutHandler, allowing downstream handlers to detect cancellation via ctx.Done().
+					// - Replace the writer with TimeoutHandler's mutex-protected writer, which safely discards concurrent writes after timeout.
+					// Both replacements preserve all original context data (route params, auth info, middleware values).
+					c.SetRequest(r)
+					c.SetResponse(echo.NewResponse(w, c.Echo()))
+					if err := next(c); err != nil {
+						// r.Context().Err() is nil means the request has not timed out, so it is safe to write the handler error response.
+						if r.Context().Err() == nil {
+							c.Echo().HTTPErrorHandler(err, c)
+						}
+					}
+				}),
+				timeout,
+				"request timeout",
+			)
+			h.ServeHTTP(c.Response().Writer, c.Request())
+			return nil
+		}
+	}
 }
 
 // RequestLimitMiddleware is a middleware function that limits the request body size to Service.MaxRequestSize in kilobytes

--- a/bootstrap/handlers/httpserver_test.go
+++ b/bootstrap/handlers/httpserver_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2023 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -20,6 +21,53 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRequestTimeoutMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		timeout        time.Duration
+		handlerDelay   time.Duration
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "handler completes before timeout",
+			timeout:        100 * time.Millisecond,
+			handlerDelay:   0,
+			expectedStatus: http.StatusOK,
+			expectedBody:   "ok",
+		},
+		{
+			name:           "handler exceeds timeout",
+			timeout:        10 * time.Millisecond,
+			handlerDelay:   500 * time.Millisecond,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "request timeout",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := echo.New()
+			e.Use(RequestTimeoutMiddleware(testCase.timeout))
+			e.GET("/", func(c echo.Context) error {
+				if testCase.handlerDelay > 0 {
+					time.Sleep(testCase.handlerDelay)
+				}
+				return c.String(http.StatusOK, "ok")
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			e.ServeHTTP(recorder, req)
+
+			assert.Equal(t, testCase.expectedStatus, recorder.Code)
+			assert.Equal(t, testCase.expectedBody, recorder.Body.String())
+		})
+	}
+}
 
 func TestRequestLimitMiddleware(t *testing.T) {
 	e := echo.New()


### PR DESCRIPTION
The Timeout middleware has architectural issues that cause data races due to response writer manipulation across goroutines. See: https://github.com/labstack/echo/releases/tag/v4.15.0

Pick commit https://github.com/edgexfoundry/go-mod-bootstrap/pull/953/changes/1652bfa160610eb573b1e91e215875e78f3a012f to fix this issue.